### PR TITLE
Better logging, minor script revisions

### DIFF
--- a/template/.vscode/tasks.json
+++ b/template/.vscode/tasks.json
@@ -60,9 +60,21 @@
         },
         {
             "label": "Start logging",
-            "detail": "Records a log to log.txt using adb logcat",
+            "detail": "Begin logging from the Quest to the console",
             "type": "shell",
-            "command": "./startlogging.bat"
+            "command": "./start-logging.ps1",
+            "windows": {
+                "command": "./start-logging.ps1"
+            }
+        },
+        {
+            "label": "Restart Beat Saber",
+            "detail": "Force-quits and restarts Beat Saber on the Quest",
+            "type": "shell",
+            "command": "./start-logging.ps1",
+            "windows": {
+                "command": "./start-logging.ps1"
+            }
         }
     ]
 }

--- a/template/build.ps1
+++ b/template/build.ps1
@@ -6,3 +6,5 @@ if (-not ($PSVersionTable.PSEdition -eq "Core")) {
 }
 
 & $buildScript NDK_PROJECT_PATH=$PSScriptRoot APP_BUILD_SCRIPT=$PSScriptRoot/Android.mk NDK_APPLICATION_MK=$PSScriptRoot/Application.mk
+
+Exit $LASTEXITCODE

--- a/template/copy.ps1
+++ b/template/copy.ps1
@@ -2,11 +2,9 @@
 if ($?) {
     adb push libs/arm64-v8a/lib#{id}.so /sdcard/Android/data/com.beatgames.beatsaber/files/mods/lib#{id}.so
     if ($?) {
-        adb shell am force-stop com.beatgames.beatsaber
-        adb shell am start com.beatgames.beatsaber/com.unity3d.player.UnityPlayerActivity
+        $PSScriptRoot/restart-game.ps1
         if ($args[0] -eq "--log") {
-            $timestamp = Get-Date -Format "MM-dd HH:mm:ss.fff"
-            adb logcat -T "$timestamp" main-modloader:W QuestHook[#{id}`|v0.1.0]:* AndroidRuntime:E *:S
+            $ $PSScriptRoot/start-logging.ps1
         }
     }
 }

--- a/template/restart-game.ps1
+++ b/template/restart-game.ps1
@@ -1,0 +1,2 @@
+adb shell am force-stop com.beatgames.beatsaber
+adb shell am start com.beatgames.beatsaber/com.unity3d.player.UnityPlayerActivity

--- a/template/start-logging.ps1
+++ b/template/start-logging.ps1
@@ -1,0 +1,7 @@
+$timestamp = Get-Date -Format "MM-dd HH:mm:ss.fff"
+$bspid = adb shell pidof com.beatgames.beatsaber
+while ([string]::IsNullOrEmpty($bspid)) {
+    Start-Sleep -Milliseconds 100
+    $bspid = adb shell pidof com.beatgames.beatsaber
+}
+adb logcat -T "$timestamp" --pid $bspid | Select-String -pattern "(QuestHook|modloader|AndroidRuntime)"

--- a/template/startlogging.bat
+++ b/template/startlogging.bat
@@ -1,2 +1,0 @@
-@ECHO OFF
-adb logcat > log.txt


### PR DESCRIPTION
- Exits `build.ps1` properly so copy script don't continue when build fails
- Splits game restart and logging into own scripts
- Better logging, displays all QuestHook, modloader, and crash logs, a bit noisier (especially on startup) but at least all codegen crashes will show the C# exception that was thrown