### PR TITLE
Remove ID

### DIFF
--- a/template/CMakeLists.txt
+++ b/template/CMakeLists.txt
@@ -27,7 +27,6 @@ add_compile_options(-frtti -fexceptions)
 add_compile_options(-O3)
 # compile definitions used
 add_compile_definitions(VERSION=\"${MOD_VERSION}\")
-add_compile_definitions(ID=\"${MOD_ID}\")
 add_compile_definitions(MOD_ID=\"${MOD_ID}\")
 
 # recursively get all src files

--- a/template/src/main.cpp
+++ b/template/src/main.cpp
@@ -17,7 +17,7 @@ Logger& getLogger() {
 
 // Called at the early stages of game loading
 extern "C" void setup(ModInfo& info) {
-    info.id = ID;
+    info.id = MOD_ID;
     info.version = VERSION;
     modInfo = info;
 	


### PR DESCRIPTION
ID breaks when including `fmt`, which becomes a much bigger problem once paperlog:tm: 🦀🦩 is deployed in bs-hooks 4.x (soon:tm:)

also fmt 🦀