### PR TITLE
add launch.json for oculus debugger (vscode ext) support

### DIFF
--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Beat Saber",
+            "type": "fb-lldb",
+            "request": "launch",
+            "preLaunchTask": "Powershell Build and Copy",
+            "android": {
+                "application": {
+                    "package": "com.beatgames.beatsaber",
+                    "activity": "com.unity3d.player.UnityPlayerActivity"
+                },
+                "lldbConfig": {
+                    "sourceMaps": [],
+                    "librarySearchPaths": [
+                        "${workspaceFolder}/build/debug/",
+                        "${workspaceFolder}/extern/libs/"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "Attach to running Beat Saber Instance",
+            "type": "fb-lldb",
+            "request": "attach",
+            "android": {
+                "application": {
+                    "package": "com.beatgames.beatsaber",
+                    "activity": "com.unity3d.player.UnityPlayerActivity"
+                },
+                "lldbConfig": {
+                    "sourceMaps": [],
+                    "librarySearchPaths": [
+                        "${workspaceFolder}/build/debug/",
+                        "${workspaceFolder}/extern/libs/",
+                    ]
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
adds support for using the oculus debugger, where using f5 will launch the game and attach a debugger, and it'll run the copy task by default before attaching (preLaunchTask)