### PR TITLE
Allow qpm.shared.json to be comitted

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -55,7 +55,6 @@ Android.mk.backup
 [Ee]xtern/
 *.qmod
 mod.json
-qpm.shared.json
 qpm_defines.cmake
 ![Cc][Mm]ake[Ll]ists.txt
 


### PR DESCRIPTION
With QPM-Rust v2, this file should not be gitignored and can be used for CI. 
`qpm-rust restore --locked`