### PR TITLE
Implement QPM.Package 0.2.0 spec

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,3 +1,6 @@
+# Ignore clangd cache
+.cache/
+
 # Prerequisites
 *.d
 

--- a/template/mod.template.json
+++ b/template/mod.template.json
@@ -9,7 +9,7 @@
   "packageVersion": "1.22.0",
   "description": "#{description}",
   "dependencies": [],
-  "modFiles": [],
+  "modFiles": ["${binary}"],
   "libraryFiles": [],
   "fileCopies": []
 }

--- a/template/qpm.json
+++ b/template/qpm.json
@@ -1,4 +1,5 @@
 {
+	"version": "0.2.0",
 	"sharedDir": "shared",
 	"dependenciesDir": "extern",
 	"workspace": {


### PR DESCRIPTION
Since QPM in 0.2.0 no longer adds the mod entries for you (e.g `lib#{id}.so`), you must add it using `${binary}` in `mod.template.json`. This does not affect other changes such as scotland2