### PR TITLE
Return build exit code in build script

### DIFF
--- a/template/scripts/build.ps1
+++ b/template/scripts/build.ps1
@@ -29,3 +29,4 @@ if (($clean.IsPresent) -or (-not (Test-Path -Path "build"))) {
 
 & cmake -G "Ninja" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -B build
 & cmake --build ./build
+exit $LASTEXITCODE


### PR DESCRIPTION
Currently running `qpm qmod zip` will zip the qmod regardless of if the build script fails, exiting with the build's exit code resolves this