### PR TITLE
Fix compile definitions not working on clean builds

### DIFF
--- a/template/CMakeLists.txt
+++ b/template/CMakeLists.txt
@@ -10,9 +10,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_compile_definitions(MOD_ID="${CMAKE_PROJECT_NAME}")
-add_compile_definitions(VERSION="${CMAKE_PROJECT_VERSION}")
-
 add_compile_options(-frtti -fexceptions -fvisibility=hidden -fPIE -fPIC)
 
 # Include. Include order matters!
@@ -45,6 +42,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/strip.cmake)
 # add_link_options(-Wl, --exclude-libs, ALL)
 project( #{id}
         VERSION ${PACKAGE_VERSION})
+
+add_compile_definitions(MOD_ID="${CMAKE_PROJECT_NAME}")
+add_compile_definitions(VERSION="${CMAKE_PROJECT_VERSION}")
 
 # Set COMPILE_ID for qpm purposes
 set(COMPILE_ID ${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
`CMAKE_PROJECT_NAME` and `CMAKE_PROJECT_VERSION` are not defined until after `project` is invoked.