### PR TITLE
Use inline for logger

### DIFF
--- a/template/include/main.hpp
+++ b/template/include/main.hpp
@@ -21,4 +21,4 @@
 // log information from other files
 Configuration &getConfig();
 
-constexpr auto PaperLogger = Paper::ConstLoggerContext("#{id}");
+inline constexpr auto PaperLogger = Paper::ConstLoggerContext("#{id}");


### PR DESCRIPTION
Avoids creating a new copy for each source file the logger is included in